### PR TITLE
added non-headless support for mfa and more

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from dotenv import load_dotenv
 load_dotenv()
-from flask import Flask, render_template, request, send_file, session, redirect, url_for
+from flask import Flask, render_template, request, send_file, session, redirect, url_for, abort
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -16,6 +16,7 @@ import zipfile
 import os
 import shutil
 import base64
+import json
 
 import logging
 from selenium.webdriver.remote.remote_connection import LOGGER as selenium_logger
@@ -32,13 +33,14 @@ app.secret_key = SECRET_KEY
 
 
 
-def initialize_driver(download_dir):
+def initialize_driver(download_dir, headless=True):
     # Set the Selenium logger to only display critical errors
     selenium_logger.setLevel(logging.CRITICAL)
 
     chrome_options = Options()
-    # Enable headless mode
-    chrome_options.add_argument("--headless")
+    # Enable headless mode if requested
+    if headless:
+        chrome_options.add_argument("--headless")
 
     prefs = {"download.default_directory": download_dir}
     chrome_options.add_experimental_option("prefs", prefs)
@@ -76,51 +78,91 @@ def cleanup_files(file_paths, download_dir):
 
 
 
-def login_to_airbnb(driver, username, password):
+def login_to_airbnb(driver, manual_mfa=False):
     try:
         logging.info("Logging into Airbnb...")
-        logging.info(f"secret key: {SECRET_KEY}")
 
         driver.get("https://www.airbnb.com/login")
 
-        # Click the "Continue with email" button
-        continue_with_email_button = WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "//button[@aria-label='Continue with email']"))
-        )
-        continue_with_email_button.click()
+        if manual_mfa:
+            # Let the user complete the entire login (including MFA) manually in the visible browser.
+            # Wait until we're no longer on the login page (up to 5 minutes).
+            WebDriverWait(driver, 300).until(lambda d: 'login' not in d.current_url)
+        else:
+            # Automated (non-MFA) fallback
+            continue_with_email_button = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.XPATH, "//button[@aria-label='Continue with email']"))
+            )
+            continue_with_email_button.click()
 
-        # Wait for the email input field to be present
-        email_field = WebDriverWait(driver, 10).until(
-            EC.presence_of_element_located((By.NAME, "user[email]"))
-        )
-        email_field.send_keys(username)
+            email_field = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.NAME, "user[email]"))
+            )
+            # Credentials removed. This path is not used in enforced MFA mode.
 
-        # Click the "Continue" button after entering email
-        continue_button = WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "//button[@data-testid='signup-login-submit-btn']"))
-        )
-        continue_button.click()
+            continue_button = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.XPATH, "//button[@data-testid='signup-login-submit-btn']"))
+            )
+            continue_button.click()
 
-        # Wait for the password input field to be present
-        password_field = WebDriverWait(driver, 10).until(
-            EC.presence_of_element_located((By.NAME, "user[password]"))
-        )
-        password_field.send_keys(password)
+            password_field = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.NAME, "user[password]"))
+            )
+            # Credentials removed. This path is not used in enforced MFA mode.
 
-        # Click the "Log in" button after entering password
-        login_button = WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.XPATH, "//button[@data-testid='signup-login-submit-btn']"))
-        )
-        login_button.click()
+            login_button = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.XPATH, "//button[@data-testid='signup-login-submit-btn']"))
+            )
+            login_button.click()
 
-        
-        time.sleep(5)  # Wait for the login process to complete
+            time.sleep(5)
     except Exception as e:
        logging.info(f"Error during login: {e}")
         # Handle the error or rethrow to be caught by calling function
 
 
 
+
+def save_session_cookies(driver, cookie_file_path):
+    try:
+        cookies = driver.get_cookies()
+        with open(cookie_file_path, 'w') as f:
+            json.dump(cookies, f)
+        logging.info(f"Saved session cookies to {cookie_file_path}")
+    except Exception as e:
+        logging.info(f"Failed to save cookies: {e}")
+
+
+def load_session_cookies(driver, cookie_file_path):
+    try:
+        if not os.path.isfile(cookie_file_path):
+            return False
+        with open(cookie_file_path, 'r') as f:
+            cookies = json.load(f)
+        # Must be on the domain before adding cookies
+        driver.get("https://www.airbnb.com/")
+        for cookie in cookies:
+            sanitized = {
+                'name': cookie.get('name'),
+                'value': cookie.get('value'),
+                'domain': cookie.get('domain'),
+                'path': cookie.get('path', '/'),
+                'secure': cookie.get('secure', False),
+            }
+            if 'expiry' in cookie:
+                sanitized['expiry'] = cookie['expiry']
+            try:
+                driver.add_cookie(sanitized)
+            except Exception as e:
+                logging.info(f"Skipping cookie add error for {sanitized.get('name')}: {e}")
+        # Verify by navigating to an authenticated page
+        driver.get("https://www.airbnb.com/hosting/reservations/all")
+        if 'login' in driver.current_url:
+            return False
+        return True
+    except Exception as e:
+        logging.info(f"Failed to load cookies: {e}")
+        return False
 
 def download_invoice(driver, booking_number, download_dir):
     downloaded_file_paths = []
@@ -150,6 +192,9 @@ def download_invoice(driver, booking_number, download_dir):
             # Since the link opens in a new tab, switch to the new tab
             driver.switch_to.window(driver.window_handles[-1])
 
+            # Ensure page fully loaded before printing
+            WebDriverWait(driver, 20).until(lambda d: d.execute_script('return document.readyState') == 'complete')
+
             # Define the parameters for the print to PDF command
             print_options = {
                 "printBackground": True,
@@ -159,7 +204,8 @@ def download_invoice(driver, booking_number, download_dir):
                 "marginTop": 0,       # Setting the top margin to 0
                 "marginBottom": 0,    # Setting the bottom margin to 0
                 "marginLeft": 0,      # Setting the left margin to 0
-                "marginRight": 0      # Setting the right margin to 0
+                "marginRight": 0,
+                "preferCSSPageSize": True
             }
 
             # Execute the print command
@@ -201,44 +247,79 @@ def zip_invoices(invoice_paths, download_dir):
 
 
 
-def scrape_airbnb_invoices(username, password, booking_numbers):
+def scrape_airbnb_invoices(booking_numbers, manual_mfa=False):
     download_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'invoice_downloads')
     if not os.path.exists(download_dir):
         os.makedirs(download_dir)
 
     total_bookings = len(booking_numbers)
     failed_downloads = []
-    driver = initialize_driver(download_dir)
+
+    # Visible browser for MFA login (or using persisted cookies)
+    driver_visible = initialize_driver(download_dir, headless=False)
+    driver_headless = None
+    cookie_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'session_cookies.json')
 
     try:
-        login_to_airbnb(driver, username, password)
+        # Try to reuse existing session cookies first
+        session_loaded = load_session_cookies(driver_visible, cookie_file_path)
+        if not session_loaded:
+            # Fall back to manual MFA login
+            login_to_airbnb(driver_visible, manual_mfa=True)
+            # Save fresh cookies after successful login
+            save_session_cookies(driver_visible, cookie_file_path)
 
-        all_downloaded_files = []  # Store all successfully downloaded invoice file paths
+        # Transfer cookies to headless browser to ensure printToPDF produces full content
+        cookies = driver_visible.get_cookies()
+        driver_headless = initialize_driver(download_dir, headless=True)
+        driver_headless.get("https://www.airbnb.com/")
+        for cookie in cookies:
+            sanitized = {
+                'name': cookie.get('name'),
+                'value': cookie.get('value'),
+                'domain': cookie.get('domain'),
+                'path': cookie.get('path', '/'),
+                'secure': cookie.get('secure', False),
+            }
+            if 'expiry' in cookie:
+                sanitized['expiry'] = cookie['expiry']
+            try:
+                driver_headless.add_cookie(sanitized)
+            except Exception as e:
+                logging.info(f"Cookie add failed for {sanitized.get('name')}: {e}")
+
+        driver_headless.get("https://www.airbnb.com/hosting/reservations/all")
+
+        all_downloaded_files = []
 
         for index, booking_number in enumerate(booking_numbers, start=1):
             logging.info(f"Downloading invoices for booking {booking_number} ({index} of {total_bookings})")
 
-            success, file_paths = download_invoice(driver, booking_number, download_dir)
+            success, file_paths = download_invoice(driver_headless, booking_number, download_dir)
 
             retry_count = 0
             while not success and retry_count < 5:
                 logging.info(f"Retrying download for booking {booking_number} (Attempt {retry_count + 1})")
-                success, file_paths = download_invoice(driver, booking_number, download_dir)
+                success, file_paths = download_invoice(driver_headless, booking_number, download_dir)
                 retry_count += 1
 
             if not success:
                 logging.info(f"Failed to download invoices for booking {booking_number} after 5 attempts")
                 failed_downloads.append(booking_number)
             else:
-                all_downloaded_files.extend(file_paths)  # Add successful downloads to the list
+                all_downloaded_files.extend(file_paths)
 
-            time.sleep(2)  # Brief delay between bookings
+            time.sleep(2)
 
     except Exception as e:
         logging.info(f"Error during invoice scraping: {e}")
-        failed_downloads.extend(booking_numbers[index:])  # Add remaining bookings to failed list
+        failed_downloads.extend(booking_numbers[index:])
     finally:
-        driver.quit()
+        try:
+            if driver_headless is not None:
+                driver_headless.quit()
+        finally:
+            driver_visible.quit()
 
     # zip the downloaded invoices here using zip_invoices function
     zip_path = zip_invoices(all_downloaded_files, download_dir)
@@ -260,15 +341,13 @@ def scrape_airbnb_invoices(username, password, booking_numbers):
 @app.route('/', methods=['GET', 'POST'])
 def index():
     if request.method == 'POST':
-        username = request.form['username']
-        password = request.form['password']
         booking_numbers = request.form.get('booking_numbers').split(',')
 
         # Filter out empty strings from booking_numbers
         booking_numbers = [number.strip() for number in booking_numbers if number.strip()]
 
         # Capture the returned values from scrape_airbnb_invoices function
-        all_downloaded_files, download_dir, failed_downloads, zip_path = scrape_airbnb_invoices(username, password, booking_numbers)
+        all_downloaded_files, download_dir, failed_downloads, zip_path = scrape_airbnb_invoices(booking_numbers, manual_mfa=True)
 
         # Trigger cleanup with a delay
         cleanup_delay = 30  # seconds, adjust as needed
@@ -294,7 +373,9 @@ def index():
 
 @app.route('/download_zip/<filename>')
 def download_zip(filename):
-    full_path = os.path.join('/Users/joseparalta/Projects/JepProjects/airbnbinvoicex/invoice_downloads', filename)
+    full_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'invoice_downloads', filename)
+    if not os.path.isfile(full_path):
+        abort(404)
     return send_file(full_path, as_attachment=True)
 
 
@@ -309,3 +390,7 @@ def complete():
 
 
 
+
+@app.errorhandler(404)
+def not_found(error):
+    return render_template('404.html'), 404

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>File Not Found</title>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Helvetica Neue', Arial, sans-serif;
+        }
+        .airbnb-style {
+            color: #FF5A5F;
+            font-weight: bold;
+        }
+    </style>
+    
+</head>
+<body class="container mt-5">
+    <h1 class="airbnb-style">Airbnb Invoice Downloader</h1>
+    <h2>We couldn't find that file.</h2>
+    <p>The download might have expired or been removed during cleanup. Please try generating the invoices again.</p>
+    <a href="{{ url_for('index') }}" class="btn btn-primary">Back to Home</a>
+</body>
+</html>
+
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -80,16 +80,10 @@
         <h1 class="airbnb-style text-center">Airbnb Invoice Downloader</h1>
         <form id="download-form" method="POST" onsubmit="toggleVisibility();" class="mt-4">
             
-            <div class="form-group">
-                <label for="username">Airbnb Username:</label>
-                <input type="text" id="username" name="username" class="form-control">
-            </div>
+            <!-- Credentials are no longer collected; login is manual via browser with MFA. -->
     
-            <div class="form-group">
-                <label for="password">Airbnb Password:</label>
-                <input type="password" id="password" name="password" class="form-control">
-            </div>
-    
+            <!-- MFA is now enforced; browser will open for manual completion. -->
+
             <div class="form-group">
                 <label for="booking_numbers">Enter Booking Numbers:</label>
                 <textarea id="booking_numbers" name="booking_numbers" class="form-control" rows="4"></textarea>


### PR DESCRIPTION
- Fixed download path: download_zip now uses the app’s invoice_downloads directory instead of a hardcoded user path.
- Added safeguards: 404 check for missing zip and a custom templates/404.html.
- Enforced MFA-only login: always opens a visible browser, waits up to 5 minutes until login completes.
- Removed credentials: deleted username/password fields from templates/index.html and backend no longer reads or uses them.
- Reduced empty PDFs:
- Added waits for full page load before printing and preferCSSPageSize.
- Introduced a two-driver flow: visible Chrome for MFA, headless Chrome for printToPDF.
- Session persistence: saves and reloads cookies to session_cookies.json to avoid repeated MFA when possible.
- Git hygiene: added .gitignore entries for session_cookies.json, invoice_downloads/, caches, and local env dirs.